### PR TITLE
Message publisher interface

### DIFF
--- a/src/Gelf/IMessagePublisher.php
+++ b/src/Gelf/IMessagePublisher.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Gelf;
+
+interface IMessagePublisher {
+    /**
+     * Publishes a Message, returns false if an error occured during write
+     *
+     * @throws UnexpectedValueException
+     * @param unknown_type $message
+     * @return boolean
+     */
+    public function publish(Message $message);
+}

--- a/src/Gelf/MessagePublisher.php
+++ b/src/Gelf/MessagePublisher.php
@@ -2,27 +2,6 @@
 
 namespace Gelf;
 
-interface IMessagePublisher {
-    /**
-     * Creates a new publisher that sends errors to a Graylog2 server via UDP
-     *
-     * @throws \InvalidArgumentException
-     * @param string $hostname
-     * @param integer $port
-     * @param integer $chunkSize
-     */
-    public function __construct($hostname, $port = self::GRAYLOG2_DEFAULT_PORT, $chunkSize = self::CHUNK_SIZE_WAN);
-
-    /**
-     * Publishes a Message, returns false if an error occured during write
-     *
-     * @throws UnexpectedValueException
-     * @param unknown_type $message
-     * @return boolean
-     */
-    public function publish(Message $message);
-}
-
 class MessagePublisher implements IMessagePublisher {
     /**
      * @var integer

--- a/src/Gelf/MessagePublisher.php
+++ b/src/Gelf/MessagePublisher.php
@@ -2,7 +2,28 @@
 
 namespace Gelf;
 
-class MessagePublisher {
+interface IMessagePublisher {
+    /**
+     * Creates a new publisher that sends errors to a Graylog2 server via UDP
+     *
+     * @throws \InvalidArgumentException
+     * @param string $hostname
+     * @param integer $port
+     * @param integer $chunkSize
+     */
+    public function __construct($hostname, $port = self::GRAYLOG2_DEFAULT_PORT, $chunkSize = self::CHUNK_SIZE_WAN);
+
+    /**
+     * Publishes a Message, returns false if an error occured during write
+     *
+     * @throws UnexpectedValueException
+     * @param unknown_type $message
+     * @return boolean
+     */
+    public function publish(Message $message);
+}
+
+class MessagePublisher implements IMessagePublisher {
     /**
      * @var integer
      */


### PR DESCRIPTION
This creates `Gelf\IMessagePublisher`, which has just the `publish` method that `Gelf\MessagePublisher` has.

This will allow things like using an interface instead of a concrete class in type hints, like @stof suggested at https://github.com/Seldaek/monolog/pull/61#r478588
