### PR TITLE
Added missing 'new' keyword

### DIFF
--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -205,7 +205,7 @@ class Message {
     public function setAdditional($key, $value) {
         if ($key == 'id')
         {
-            throw \InvalidArgumentException('The "id" additional field is not allowed.');
+            throw new \InvalidArgumentException('The "id" additional field is not allowed.');
         }
 
         $this->data["_" . trim($key)] = $value;


### PR DESCRIPTION
This is a small bug fix to add the 'new' keyword where an exception is thrown.
