### PR TITLE
Support for Graylog2's HTTP input

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,10 @@
     "authors": [
         {
             "name": "Matt Lehner",
-            "email": "matt.lehner@tellecore.com"
+            "email": "matt.lehner@tellecore.com",
+            
+            "name": "Benjamin Zikarsky",
+            "email": "benjamin.zikarsky@perbility.de"
         }
     ],
     "require": {},

--- a/src/Gelf/HttpMessagePublisher.php
+++ b/src/Gelf/HttpMessagePublisher.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Gelf;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+class HttpMessagePublisher implements IMessagePublisher {
+
+  
+    const DEFAULT_PORT = 12202;
+    const DEFAULT_HOST = "127.0.0.1";
+    const DEFAULT_PATH = "/gelf";
+    
+    /**
+     * The host the HTTP receiver is on
+     * 
+     * @var string
+     */
+    protected $host;
+    
+    /**
+     * The port the HTTP receiver listens on
+     * 
+     * @var int
+     */
+    protected $port;
+    
+    /**
+     * The URL path the reciver listens on
+     * 
+     * @var string
+     */
+    protected $path;
+    
+    /**
+     * Creates an HttpMessagePublishes which can send Gelf\Message Objects to 
+     * a Graylog2 server via HTTP
+     * 
+     * @param string $host
+     * @param int $port
+     * @param string $path
+     * @throws InvalidArgumentException
+     */
+    public function __construct($host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT, $path = self::DEFAULT_PATH) {
+        if (!$host) {
+            throw new InvalidArgumentException("\$host must not be empty");
+        }
+        
+        if (!is_int($port) || $port < 1 || $port > 65535) {
+            throw new InvalidArgumentException("\$port must be an int in the range 1-65535");
+        }
+        
+        if (strlen($path) < 1 || $path[0] != '/') {
+            throw new InvalidArgumentException("\$path must not be empty and start with a slash");
+        }
+        
+        $this->host = $host;
+        $this->port = $port;
+        $this->path = $path;
+    }
+    
+
+    /**
+     * Publishes a Message, returns false if an error occured during write
+     *
+     * @throws UnexpectedValueException
+     * @param Gelf\Message $message
+     * @return boolean
+     */
+    public function publish(Message $message) {
+        // prepare GELF message
+        $message->setVersion(self::GRAYLOG2_PROTOCOL_VERSION);
+        $jsonMessage = json_encode($message->toArray());
+        
+        // create and send http request
+        $httpRequest = $this->prepareHttpRequest($jsonMessage);
+        $socket = $this->getSocket();
+        if (false === fwrite($socket, $httpRequest)) {
+            throw new RuntimeException("fwrite failed");
+        }
+        
+        fclose($socket);
+        return true;
+    }
+    
+    /**
+     * Creates a valid HTTP-Request string
+     * 
+     * @param string $body
+     * @return string
+     */
+    protected function prepareHttpRequest($body) {
+        $request = "POST %s HTTP.1.1\r\n"
+                 . "Host: %s\r\n"
+                 . "Content-Type: application/json\r\n"
+                 . "Content-Length: %d\r\n"
+                 . "Connection: Close\r\n"
+                 . "\r\n"
+                 . "%s";
+        
+        return sprintf($request, $this->path, $this->host, strlen($body), $body);
+    }
+    
+    /**
+     * Returns an open socket to $this->host:$this->port
+     * 
+     * @throws RuntimeException
+     * @return resource
+     */
+    protected function getSocket() {
+        $socket = fsockopen($this->host, $this->port, $errno, $errstr);
+        if (!$socket) {
+            throw new RuntimeException("fsockopen on {$this->host}:{$this->port} failed");
+        }
+        
+        return $socket;
+    }
+    
+    
+}

--- a/src/Gelf/IMessagePublisher.php
+++ b/src/Gelf/IMessagePublisher.php
@@ -3,6 +3,12 @@
 namespace Gelf;
 
 interface IMessagePublisher {
+    
+    /**
+     * @var string
+     */
+    const GRAYLOG2_PROTOCOL_VERSION = '1.0';
+    
     /**
      * Publishes a Message, returns false if an error occured during write
      *

--- a/src/Gelf/IMessagePublisher.php
+++ b/src/Gelf/IMessagePublisher.php
@@ -7,7 +7,7 @@ interface IMessagePublisher {
      * Publishes a Message, returns false if an error occured during write
      *
      * @throws UnexpectedValueException
-     * @param unknown_type $message
+     * @param Gelf\Message $message
      * @return boolean
      */
     public function publish(Message $message);

--- a/src/Gelf/MessagePublisher.php
+++ b/src/Gelf/MessagePublisher.php
@@ -21,11 +21,6 @@ class MessagePublisher implements IMessagePublisher {
     /**
      * @var string
      */
-    const GRAYLOG2_PROTOCOL_VERSION = '1.0';
-
-    /**
-     * @var string
-     */
     protected $hostname = null;
 
     /**


### PR DESCRIPTION
Added an HttpMessagePublisher which supports the GELF HTTP Input (http://support.torch.sh/help/kb/graylog2-server/using-the-gelf-http-input)
