### PR TITLE
add branch-alias to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,10 @@
     },
     "autoload": {
         "psr-0": {"Gelf": "src/"}
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
like this, people can depend on the latest version of gelf-php without needing to require `dev-master`.

btw, what about tagging a 1.1.1 release with the latest bugfix?
